### PR TITLE
adding train_x variable in SETSTCF for feat mode

### DIFF
--- a/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py
+++ b/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py
@@ -88,6 +88,7 @@ class SETSCF(CF):
             self.ts_len = train_x.shape[1]
         elif mode == "feat":
             change = False
+            self.train_x = np.array(train_x)
             self.ts_len = train_x.shape[2]
         self.train_x_n = from_3d_numpy_to_nested(self.train_x)
         if backend == "PYT":


### PR DESCRIPTION
Hello, 
i'm currently working with xai for tsc using TSInterpret and @aeon-toolkit/aeon . I tried SET with HIVECOTE2 and face this issue : 
``` python
[91](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kndb/Dev/Phd-Code/explainability/MTS/~/Dev/Phd-Code/explainability/MTS/venv/lib/python3.10/site-packages/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py:91)     # self.train_x = np.array(train_x)
     [92](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kndb/Dev/Phd-Code/explainability/MTS/~/Dev/Phd-Code/explainability/MTS/venv/lib/python3.10/site-packages/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py:92)     self.ts_len = train_x.shape[2]
---> [94](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kndb/Dev/Phd-Code/explainability/MTS/~/Dev/Phd-Code/explainability/MTS/venv/lib/python3.10/site-packages/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py:94) self.train_x_n = from_3d_numpy_to_nested(self.train_x)
     [95](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kndb/Dev/Phd-Code/explainability/MTS/~/Dev/Phd-Code/explainability/MTS/venv/lib/python3.10/site-packages/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py:95) if backend == "PYT":
     [96](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kndb/Dev/Phd-Code/explainability/MTS/~/Dev/Phd-Code/explainability/MTS/venv/lib/python3.10/site-packages/TSInterpret/InterpretabilityModels/counterfactual/SETSCF.py:96)     self.predict = PyTorchModel(model, change).predict

AttributeError: 'SETSCF' object has no attribute 'train_x'
``` 

After looking in the source code i figure out that when the mode == 'feat' you didn't add the train_x variable. I just add it in this PR :). 

