### PR TITLE
Fix: Correct TypeError in EvoUtils.py

### DIFF
--- a/TSInterpret/InterpretabilityModels/counterfactual/TSEvo/EvoUtils.py
+++ b/TSInterpret/InterpretabilityModels/counterfactual/TSEvo/EvoUtils.py
@@ -348,5 +348,5 @@ def mutate_hyperperameter(ind1, window, channels, num_channels):
     window = window
     channels = channels
     if random.random() < 0.5:
-        window = random.randint(1, np.floor(0.5 * np.array(ind1).shape[-1]))
+        window = random.randint(1, int(np.floor(0.5 * np.array(ind1).shape[-1])))
     return window, channels


### PR DESCRIPTION
### **Title:**

`Fix: Correct TypeError in EvoUtils.(Line 351) py for random.randint`

-----

### **Description:**

This pull request resolves a `TypeError` that occurs when calling `random.randint` with a `numpy.float64` argument.

#### **The Problem**

In the file `EvoUtils.py`, the `window` size is calculated using `np.floor()`, which returns a `numpy.float64` type. This float value is then passed directly to `random.randint()`.

Modern versions of NumPy and Python's `random` library enforce strict type checking, and `random.randint()` requires integer arguments. This mismatch causes a `TypeError`, crashing the execution.

  * **Before:**
    ```python
    window = random.randint(1, np.floor(0.5 * np.array(ind1).shape[-1]))
    ```

#### **The Solution**

The fix is to explicitly cast the result of the `np.floor()` operation to an integer using `int()` before passing it to `random.randint`. This ensures the function receives arguments of the correct type.

  * **After:**
    ```python
    window = random.randint(1, int(np.floor(0.5 * np.array(ind1).shape[-1])))
    ```
